### PR TITLE
Fix independent gain, add current cost

### DIFF
--- a/src/data/common.tsx
+++ b/src/data/common.tsx
@@ -80,7 +80,7 @@ export function createResetButton<T extends ClickableOptions & ResetButtonOption
                     <b>
                         {displayResource(
                             resetButton.conversion.gainResource,
-                            unref(resetButton.conversion.currentGain)
+                            unref(resetButton.conversion.actualGain)
                         )}
                     </b>{" "}
                     {resetButton.conversion.gainResource.displayName}
@@ -99,7 +99,7 @@ export function createResetButton<T extends ClickableOptions & ResetButtonOption
 
         if (resetButton.canClick == null) {
             resetButton.canClick = computed(() =>
-                Decimal.gt(unref(resetButton.conversion.currentGain), 0)
+                Decimal.gt(unref(resetButton.conversion.actualGain), 0)
             );
         }
 


### PR DESCRIPTION
Independent conversions were subtracting the current resource amount from the expected gain, while the `nextAt` and `convert` functions were designed with a static `currentGain` in mind. This discrepancy was causing the displayed `currentGain` and `nextAt` value to "jump" immediately after a reset, and to produce erroneous values (e.g. after resetting for 5 points, attaining the original resource amount would allow you to reset for 4, then after resetting for those 4, which would drop you from 5 points to 4, you could once again reset for 5).

Moving the subtraction to a display-only `actualGain` function allows the `currentGain` function to work as intended, without interfering with the surrounding conversion functionality.

Additionally, a `currentAt` function has been added, to allow for displaying current costs or for use in custom `convert` functions, if the developer wishes to do so.