### PR TITLE
Improve lazy proxy typing

### DIFF
--- a/src/data/common.tsx
+++ b/src/data/common.tsx
@@ -437,7 +437,7 @@ export function estimateTime(
         const currTarget = unref(processedTarget);
         if (Decimal.gte(resource.value, currTarget)) {
             return "Now";
-        } else if (Decimal.lt(currRate, 0)) {
+        } else if (Decimal.lte(currRate, 0)) {
             return "Never";
         }
         return formatTime(Decimal.sub(currTarget, resource.value).div(currRate));

--- a/src/features/achievements/achievement.tsx
+++ b/src/features/achievements/achievement.tsx
@@ -182,6 +182,13 @@ export function createAchievement<T extends AchievementOptions>(
             decorator.preConstruct?.(achievement);
         }
         Object.assign(achievement, decoratedData);
+        for (const decorator of decorators) {
+            decorator.postConstruct?.(achievement);
+        }
+        const decoratedProps = decorators.reduce(
+            (current, next) => Object.assign(current, next.getGatheredProps?.(achievement)),
+            {}
+        );
 
         function complete() {
             earned.value = true;
@@ -209,12 +216,7 @@ export function createAchievement<T extends AchievementOptions>(
             }
         }
 
-        const decoratedProps = decorators.reduce(
-            (current, next) => Object.assign(current, next.getGatheredProps?.(achievement)),
-            {}
-        );
-
-        function gatherProps(this: Achievement<T>): Record<string, unknown> {
+        function gatherProps(this: GenericAchievement): Record<string, unknown> {
             const {
                 visibility,
                 display,
@@ -240,10 +242,6 @@ export function createAchievement<T extends AchievementOptions>(
                 id,
                 ...decoratedProps
             };
-        }
-
-        for (const decorator of decorators) {
-            decorator.postConstruct?.(achievement);
         }
 
         if (achievement.requirements != null) {

--- a/src/features/achievements/achievement.tsx
+++ b/src/features/achievements/achievement.tsx
@@ -32,7 +32,7 @@ import { camelToTitle } from "util/common";
 import { Computable, Defaults, ProcessedFeature, convertComputable } from "util/computed";
 import { createLazyProxy } from "util/proxies";
 import { coerceComponent, isCoercableComponent } from "util/vue";
-import { ComputedRef, nextTick, unref, watchEffect } from "vue";
+import { ComputedRef, unref, watchEffect } from "vue";
 import { useToast } from "vue-toastification";
 
 const toast = useToast();
@@ -105,30 +105,6 @@ export interface BaseAchievement {
     [GatherProps]: () => Record<string, unknown>;
 }
 
-/** An object that represents a feature with requirements that is passively earned upon meeting certain requirements. */
-// export type Achievement<T extends AchievementOptions> = Replace<
-//     T & BaseAchievement,
-//     {
-//         visibility: GetComputableTypeWithDefault<T["visibility"], Visibility.Visible>;
-//         display: GetComputableType<T["display"]>;
-//         mark: GetComputableType<T["mark"]>;
-//         image: GetComputableType<T["image"]>;
-//         style: GetComputableType<T["style"]>;
-//         classes: GetComputableType<T["classes"]>;
-//         showPopups: GetComputableTypeWithDefault<T["showPopups"], true>;
-//     }
-// >;
-
-// export interface Achievement extends AchievementOptions, BaseAchievement {
-//     visibility: GetComputableTypeWithDefault<AchievementOptions["visibility"], Visibility.Visible>;
-//     display: GetComputableType<AchievementOptions["display"]>;
-//     mark: GetComputableType<AchievementOptions["mark"]>;
-//     image: GetComputableType<AchievementOptions["image"]>;
-//     style: GetComputableType<AchievementOptions["style"]>;
-//     classes: GetComputableType<AchievementOptions["classes"]>;
-//     showPopups: GetComputableTypeWithDefault<AchievementOptions["showPopups"], true>;
-// }
-
 export type Achievement<T extends AchievementOptions> = BaseAchievement &
     ProcessedFeature<AchievementOptions, Exclude<T, BaseAchievement>> &
     Defaults<
@@ -141,154 +117,6 @@ export type Achievement<T extends AchievementOptions> = BaseAchievement &
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type GenericAchievement = Achievement<any>;
 
-/**
- * Lazily creates an achievement with the given options.
- * @param optionsFunc Achievement options.
- */
-// export function createAchievement<T extends AchievementOptions>(
-//     optionsFunc?: OptionsFunc<T, GenericAchievement>,
-//     ...decorators: GenericDecorator[]
-// ): Achievement<T> {
-//     const earned = persistent<boolean>(false, false);
-//     const decoratedData = decorators.reduce(
-//         (current, next) => Object.assign(current, next.getPersistentData?.()),
-//         {}
-//     );
-//     return createLazyProxy(feature => {
-//         const achievement =
-//             optionsFunc?.call(feature, feature) ??
-//             ({} as ReturnType<NonNullable<typeof optionsFunc>>);
-//         achievement.id = getUniqueID("achievement-");
-//         achievement.type = AchievementType;
-//         achievement[Component] = AchievementComponent as GenericComponent;
-
-//         for (const decorator of decorators) {
-//             decorator.preConstruct?.(achievement);
-//         }
-
-//         achievement.display = convertComputable(achievement.display, achievement);
-//         achievement.mark = convertComputable(achievement.mark, achievement);
-//         achievement.small = convertComputable(achievement.small, achievement);
-//         achievement.image = convertComputable(achievement.image, achievement);
-//         achievement.style = convertComputable(achievement.style, achievement);
-//         achievement.classes = convertComputable(achievement.classes, achievement);
-//         achievement.showPopups = convertComputable(achievement.showPopups, achievement) ?? true;
-
-//         achievement.earned = earned;
-//         achievement.complete = function () {
-//             earned.value = true;
-//             achievement.onComplete?.();
-//             if (achievement.display != null && unref(achievement.showPopups) === true) {
-//                 const display = unref((achievement as GenericAchievement).display);
-//                 let Display;
-//                 if (isCoercableComponent(display)) {
-//                     Display = coerceComponent(display);
-//                 } else if (display.requirement != null) {
-//                     Display = coerceComponent(display.requirement);
-//                 } else {
-//                     Display = displayRequirements(achievement.requirements ?? []);
-//                 }
-//                 toast.info(
-//                     <div>
-//                         <h3>Achievement earned!</h3>
-//                         <div>
-//                             {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
-//                             {/* @ts-ignore */}
-//                             <Display />
-//                         </div>
-//                     </div>
-//                 );
-//             }
-//         };
-
-//         Object.assign(achievement, decoratedData);
-
-//         const visibility =
-//             convertComputable(achievement.visibility, achievement) ?? Visibility.Visible;
-//         achievement.visibility = computed(() => {
-//             const display = unref(achievement.display);
-//             switch (settings.msDisplay) {
-//                 default:
-//                 case AchievementDisplay.All:
-//                     return unref(visibility);
-//                 case AchievementDisplay.Configurable:
-//                     if (
-//                         unref(achievement.earned) &&
-//                         !(
-//                             display != null &&
-//                             typeof display == "object" &&
-//                             "optionsDisplay" in (display as Record<string, unknown>)
-//                         )
-//                     ) {
-//                         return Visibility.None;
-//                     }
-//                     return unref(visibility);
-//                 case AchievementDisplay.Incomplete:
-//                     if (unref(achievement.earned)) {
-//                         return Visibility.None;
-//                     }
-//                     return unref(visibility);
-//                 case AchievementDisplay.None:
-//                     return Visibility.None;
-//             }
-//         });
-
-//         for (const decorator of decorators) {
-//             decorator.postConstruct?.(achievement);
-//         }
-
-//         const decoratedProps = decorators.reduce(
-//             (current, next) => Object.assign(current, next.getGatheredProps?.(achievement)),
-//             {}
-//         );
-//         achievement[GatherProps] = function () {
-//             const {
-//                 visibility,
-//                 display,
-//                 requirements,
-//                 earned,
-//                 image,
-//                 style,
-//                 classes,
-//                 mark,
-//                 small,
-//                 id
-//             } = this;
-//             return {
-//                 visibility,
-//                 display,
-//                 requirements,
-//                 earned,
-//                 image,
-//                 style: unref(style),
-//                 classes,
-//                 mark,
-//                 small,
-//                 id,
-//                 ...decoratedProps
-//             };
-//         };
-
-//         if (achievement.requirements) {
-//             const requirements = [
-//                 createVisibilityRequirement(achievement),
-//                 createBooleanRequirement(() => !achievement.earned.value),
-//                 ...(isArray(achievement.requirements)
-//                     ? achievement.requirements
-//                     : [achievement.requirements])
-//             ];
-//             watchEffect(() => {
-//                 if (settings.active !== player.id) return;
-//                 if (requirementsMet(requirements)) {
-//                     achievement.complete();
-//                 }
-//             });
-//         }
-
-//         return achievement;
-//     });
-// }
-
 export function createAchievement<T extends AchievementOptions>(
     optionsFunc?: OptionsFunc<T, GenericAchievement>,
     ...decorators: GenericDecorator[]
@@ -298,42 +126,13 @@ export function createAchievement<T extends AchievementOptions>(
         (current, next) => Object.assign(current, next.getPersistentData?.()),
         {}
     );
-    return createLazyProxy(achievement => {
-        const options =
-            optionsFunc?.call(achievement, achievement) ??
+    return createLazyProxy(feature => {
+        const { visibility, display, mark, small, image, style, classes, showPopups, ...options } =
+            optionsFunc?.call(feature, feature) ??
             ({} as ReturnType<NonNullable<typeof optionsFunc>>);
 
-        function complete() {
-            earned.value = true;
-            (achievement as GenericAchievement).onComplete?.();
-            if (achievement.display != null && unref(achievement.showPopups) === true) {
-                const display = unref((achievement as GenericAchievement).display);
-                let Display;
-                if (isCoercableComponent(display)) {
-                    Display = coerceComponent(display);
-                } else if (display.requirement != null) {
-                    Display = coerceComponent(display.requirement);
-                } else {
-                    Display = displayRequirements(
-                        (achievement as GenericAchievement).requirements ?? []
-                    );
-                }
-                toast.info(
-                    <div>
-                        <h3>Achievement earned!</h3>
-                        <div>
-                            {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
-                            {/* @ts-ignore */}
-                            <Display />
-                        </div>
-                    </div>
-                );
-            }
-        }
-
-        const optionsVisibility =
-            convertComputable(options.visibility, options) ?? Visibility.Visible;
-        const visibility = computed(() => {
+        const optionsVisibility = convertComputable(visibility, feature) ?? Visibility.Visible;
+        const processedVisibility = computed(() => {
             const display = unref(achievement.display);
             switch (settings.msDisplay) {
                 default:
@@ -361,17 +160,61 @@ export function createAchievement<T extends AchievementOptions>(
             }
         });
 
+        const achievement = {
+            id: getUniqueID("achievement-"),
+            visibility: processedVisibility,
+            earned,
+            complete,
+            type: AchievementType,
+            [Component]: AchievementComponent as GenericComponent,
+            [GatherProps]: gatherProps,
+            display: convertComputable(display, feature),
+            mark: convertComputable(mark, feature),
+            small: convertComputable(small, feature),
+            image: convertComputable(image, feature),
+            style: convertComputable(style, feature),
+            classes: convertComputable(classes, feature),
+            showPopups: convertComputable(showPopups, feature) ?? true,
+            ...options
+        } satisfies Partial<Achievement<T>>;
+
         for (const decorator of decorators) {
             decorator.preConstruct?.(achievement);
         }
         Object.assign(achievement, decoratedData);
+
+        function complete() {
+            earned.value = true;
+            achievement.onComplete?.();
+            if (achievement.display != null && unref(achievement.showPopups) === true) {
+                const display = unref(achievement.display);
+                let Display;
+                if (isCoercableComponent(display)) {
+                    Display = coerceComponent(display);
+                } else if (display.requirement != null) {
+                    Display = coerceComponent(display.requirement);
+                } else {
+                    Display = displayRequirements(achievement.requirements ?? []);
+                }
+                toast.info(
+                    <div>
+                        <h3>Achievement earned!</h3>
+                        <div>
+                            {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
+                            {/* @ts-ignore */}
+                            <Display />
+                        </div>
+                    </div>
+                );
+            }
+        }
 
         const decoratedProps = decorators.reduce(
             (current, next) => Object.assign(current, next.getGatheredProps?.(achievement)),
             {}
         );
 
-        function gatherProps(this: Achievement<T>) {
+        function gatherProps(this: Achievement<T>): Record<string, unknown> {
             const {
                 visibility,
                 display,
@@ -399,46 +242,27 @@ export function createAchievement<T extends AchievementOptions>(
             };
         }
 
-        nextTick(() => {
-            for (const decorator of decorators) {
-                decorator.postConstruct?.(achievement);
-            }
+        for (const decorator of decorators) {
+            decorator.postConstruct?.(achievement);
+        }
 
-            if (achievement.requirements) {
-                const requirements = [
-                    createVisibilityRequirement(achievement as GenericAchievement),
-                    createBooleanRequirement(() => !achievement.earned.value),
-                    ...(isArray(achievement.requirements)
-                        ? achievement.requirements
-                        : [achievement.requirements])
-                ];
-                watchEffect(() => {
-                    if (settings.active !== player.id) return;
-                    if (requirementsMet(requirements)) {
-                        achievement.complete();
-                    }
-                });
-            }
-        });
+        if (achievement.requirements != null) {
+            const requirements = [
+                createVisibilityRequirement(achievement),
+                createBooleanRequirement(() => !earned.value),
+                ...(isArray(achievement.requirements)
+                    ? achievement.requirements
+                    : [achievement.requirements])
+            ];
+            watchEffect(() => {
+                if (settings.active !== player.id) return;
+                if (requirementsMet(requirements)) {
+                    achievement.complete();
+                }
+            });
+        }
 
-        return {
-            id: getUniqueID("achievement-"),
-            visibility,
-            earned,
-            complete,
-            type: AchievementType,
-            [Component]: AchievementComponent as GenericComponent,
-            [GatherProps]: gatherProps,
-            requirements: options.requirements,
-            display: convertComputable(options.display, options),
-            mark: convertComputable(options.mark, options),
-            small: convertComputable(options.small, options),
-            image: convertComputable(options.image, options),
-            style: convertComputable(options.style, options),
-            classes: convertComputable(options.classes, options),
-            showPopups: convertComputable(options.showPopups, options) ?? true,
-            onComplete: options.onComplete
-        } /* as Achievement<T>*/;
+        return achievement;
     });
 }
 
@@ -457,6 +281,10 @@ ach.foo; // "bar"
 ach.bar; // () => "foo"
 ach.mark; // TS should yell about this not existing (or at least mark it undefined)
 ach.visibility; // ComputedRef<Visibility | boolean>
+
+const badAch = createAchievement(() => ({
+    requirements: "foo"
+}));
 
 declare module "game/settings" {
     interface Settings {

--- a/src/features/feature.ts
+++ b/src/features/feature.ts
@@ -42,9 +42,9 @@ export type Replace<T, S> = S & Omit<T, keyof S>;
  * with "this" bound to what the type will eventually be processed into.
  * Intended for making lazily evaluated objects.
  */
-export type OptionsFunc<T, R = unknown, S = R> = (obj: R) => OptionsObject<T, R, S>;
+export type OptionsFunc<T, R = unknown> = (this: R, obj: R) => OptionsObject<T, R>;
 
-export type OptionsObject<T, R = unknown, S = R> = T & Partial<R> & ThisType<T & S>;
+export type OptionsObject<T, R = unknown> = Exclude<T, R> & Partial<R>;
 
 let id = 0;
 /**

--- a/src/util/computed.ts
+++ b/src/util/computed.ts
@@ -1,6 +1,6 @@
 import type { JSXFunction } from "features/feature";
 import { isFunction } from "util/common";
-import type { Ref } from "vue";
+import type { ComputedRef, Ref } from "vue";
 import { computed } from "vue";
 
 export const DoNotCache = Symbol("DoNotCache");
@@ -26,32 +26,71 @@ export type ComputableKeysOf<T> = Pick<
     }[keyof T]
 >;
 
+export type ProcessedFeature<T, S extends T> = {
+    [K in keyof S]: K extends keyof T
+        ? T[K] extends Computable<infer R>
+            ? S[K] extends () => infer Q
+                ? ComputedRef<Q>
+                : S[K]
+            : S[K]
+        : S[K];
+};
+
+export type Defaults<T, S> = {
+    [K in keyof S]: K extends keyof T ? (T[K] extends undefined ? S[K] : T[K]) : S[K];
+};
+
 // TODO fix the typing of this function, such that casting isn't necessary and can be used to
 // detect if a createX function is validly written
-export function processComputable<T, S extends keyof ComputableKeysOf<T>>(
-    obj: T,
-    key: S
-): asserts obj is T & { [K in S]: ProcessedComputable<UnwrapComputableType<T[S]>> } {
-    const computable = obj[key];
-    if (
-        isFunction(computable) &&
-        computable.length === 0 &&
-        !(computable as unknown as JSXFunction)[DoNotCache]
-    ) {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        obj[key] = computed(computable.bind(obj));
-    } else if (isFunction(computable)) {
-        obj[key] = computable.bind(obj) as unknown as T[S];
-        (obj[key] as unknown as JSXFunction)[DoNotCache] = true;
-    }
+// export function processComputable<
+//     T extends object,
+//     S extends keyof {
+//         [K in keyof T]: T[K] extends Computable<unknown> ? K : never;
+//     },
+//     R = T[S]
+// >(
+//     obj: T,
+//     key: S
+// ): asserts obj is {
+//     [K in keyof T]: K extends keyof S ? S[K] extends ProcessedComputable<UnwrapComputableType<R>> : T[K];
+// } {
+//     const computable = obj[key];
+//     if (
+//         isFunction(computable) &&
+//         computable.length === 0 &&
+//         !(computable as unknown as JSXFunction)[DoNotCache]
+//     ) {
+//         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+//         // @ts-ignore
+//         obj[key] = computed(computable.bind(obj));
+//     } else if (isFunction(computable)) {
+//         obj[key] = computable.bind(obj) as unknown as T[S];
+//         (obj[key] as unknown as JSXFunction)[DoNotCache] = true;
+//     }
+// }
+
+function isJSXFunction(value: unknown): value is JSXFunction {
+    return typeof value === "function" && DoNotCache in value && value[DoNotCache] === true;
 }
 
-export function convertComputable<T>(obj: Computable<T>): ProcessedComputable<T> {
-    if (isFunction(obj) && !(obj as unknown as JSXFunction)[DoNotCache]) {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
+export function convertComputable<T>(
+    obj: Computable<NonNullable<T>>,
+    thisArg?: object
+): typeof obj extends JSXFunction ? typeof obj : ProcessedComputable<T>;
+export function convertComputable(obj: undefined, thisArg?: object): undefined;
+export function convertComputable<T>(
+    obj: Computable<T> | undefined,
+    thisArg?: object
+): (typeof obj extends JSXFunction ? typeof obj : ProcessedComputable<T>) | undefined;
+export function convertComputable<T>(
+    obj: Computable<T> | undefined,
+    thisArg?: object
+) /*: (typeof obj extends JSXFunction ? typeof obj : ProcessedComputable<T>) | undefined*/ {
+    if (isFunction(obj) && !isJSXFunction(obj)) {
+        if (thisArg != null) {
+            obj = obj.bind(thisArg);
+        }
         obj = computed(obj);
     }
-    return obj as ProcessedComputable<T>;
+    return obj;
 }


### PR DESCRIPTION
Remaining work would be:
- Update every other feature, and any relevant utilities (like in common.tsx)
- Implement processComputable, or remove it since it might just be redundant now
- Remember to delete the example achievement below the constructor, that I was using to verify typing was working
- This code doesn't work, because `feature` gets typed as `object`:
```ts
function myFeature() {
    return createLazyProxy(() => {
        const foo = "bar";
        const points = createAchievement(() => ({

        }));
        return {
            foo, points
        };
    });
}

const feature = myFeature();
feature;
feature.foo;
feature.points;
```

Fixes #15 