### PR TITLE
Made calculateMaxAffordable, calculateCost, and cost requirements interface a bit cleaner

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,18 +1,25 @@
 <template>
-    <div id="modal-root" :style="theme" />
-    <div class="app" :style="theme" :class="{ useHeader }">
-        <Nav v-if="useHeader" />
-        <Game />
-        <TPS v-if="unref(showTPS)" />
-        <GameOverScreen />
-        <NaNScreen />
-        <component :is="gameComponent" />
-    </div>
+    <div v-if="appErrors.length > 0" class="error-container" :style="theme"><Error :errors="appErrors" /></div>
+    <template v-else>
+        <div id="modal-root" :style="theme" />
+        <div class="app" :style="theme" :class="{ useHeader }">
+            <Nav v-if="useHeader" />
+            <Game />
+            <TPS v-if="unref(showTPS)" />
+            <GameOverScreen />
+            <NaNScreen />
+            <component :is="gameComponent" />
+        </div>
+    </template>
 </template>
 
 <script setup lang="tsx">
+import "@fontsource/roboto-mono";
+import Error from "components/Error.vue";
 import { jsx } from "features/feature";
+import state from "game/state";
 import { coerceComponent, render } from "util/vue";
+import { CSSProperties, watch } from "vue";
 import { computed, toRef, unref } from "vue";
 import Game from "./components/Game.vue";
 import GameOverScreen from "./components/GameOverScreen.vue";
@@ -23,12 +30,11 @@ import projInfo from "./data/projInfo.json";
 import themes from "./data/themes";
 import settings, { gameComponents } from "./game/settings";
 import "./main.css";
-import "@fontsource/roboto-mono";
-import type { CSSProperties } from "vue";
 
 const useHeader = projInfo.useHeader;
 const theme = computed(() => themes[settings.theme].variables as CSSProperties);
 const showTPS = toRef(settings, "showTPS");
+const appErrors = toRef(state, "errors");
 
 const gameComponent = computed(() => {
     return coerceComponent(jsx(() => (<>{gameComponents.map(render)}</>)));
@@ -50,5 +56,16 @@ const gameComponent = computed(() => {
     min-height: 100%;
     height: 100%;
     color: var(--foreground);
+}
+
+.error-container {
+    background: var(--background);
+    overflow: auto;
+    width: 100%;
+    height: 100%;
+}
+
+.error-container > .error {
+    position: static;
 }
 </style>

--- a/src/components/Error.vue
+++ b/src/components/Error.vue
@@ -1,0 +1,103 @@
+<template>
+    <div class="error">
+        <h1 class="error-title">{{ firstError.name }}: {{ firstError.message }}</h1>
+        <div class="error-details" style="margin-top: -10px">
+            <div v-if="firstError.cause">
+                <div v-for="row in causes[0]" :key="row">{{ row }}</div>
+            </div>
+            <div v-if="firstError.stack" :style="firstError.cause ? 'margin-top: 10px' : ''">
+                <div v-for="row in stacks[0]" :key="row">{{ row }}</div>
+            </div>
+        </div>
+        <div class="instructions">
+            Check the console for more details, and consider sharing it with the developers on
+            <a :href="projInfo.discordLink || 'https://discord.gg/yJ4fjnjU54'" class="discord-link"
+                >discord</a
+            >!<br />
+            <div v-if="errors.length > 1" style="margin-top: 20px"><h3>Other errors</h3></div>
+            <div v-for="(error, i) in errors.slice(1)" :key="i" style="margin-top: 20px">
+                <details class="error-details">
+                    <summary>{{ error.name }}: {{ error.message }}</summary>
+                    <div v-if="error.cause" style="margin-top: 10px">
+                        <div v-for="row in causes[i + 1]" :key="row">{{ row }}</div>
+                    </div>
+                    <div v-if="error.stack" style="margin-top: 10px">
+                        <div v-for="row in stacks[i + 1]" :key="row">{{ row }}</div>
+                    </div>
+                </details>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import projInfo from "data/projInfo.json";
+import player from "game/player";
+import { computed, onMounted } from "vue";
+
+const props = defineProps<{
+    errors: Error[];
+}>();
+
+const firstError = computed(() => props.errors[0]);
+const stacks = computed(() =>
+    props.errors.map(error => (error.stack == null ? [] : error.stack.split("\n")))
+);
+const causes = computed(() =>
+    props.errors.map(error =>
+        error.cause == null
+            ? []
+            : (typeof error.cause === "string" ? error.cause : JSON.stringify(error.cause)).split(
+                  "\n"
+              )
+    )
+);
+
+onMounted(() => {
+    player.autosave = false;
+    player.devSpeed = 0;
+});
+</script>
+
+<style scoped>
+.error {
+    border: solid 10px var(--danger);
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    text-align: left;
+    min-height: calc(100% - 20px);
+    text-align: left;
+    color: var(--foreground);
+}
+
+.error-title {
+    background: var(--danger);
+    color: var(--feature-foreground);
+    display: block;
+    margin: -10px 0 10px 0;
+    position: sticky;
+    top: 0;
+}
+
+.error-details {
+    white-space: nowrap;
+    overflow: auto;
+    padding: 10px;
+    background-color: var(--raised-background);
+}
+
+.instructions {
+    padding: 10px;
+}
+
+.discord-link {
+    display: inline;
+}
+
+summary {
+    cursor: pointer;
+    user-select: none;
+}
+</style>

--- a/src/components/Layer.vue
+++ b/src/components/Layer.vue
@@ -1,5 +1,6 @@
 <template>
-    <div class="layer-container" :style="{ '--layer-color': unref(color) }">
+    <ErrorVue v-if="errors.length > 0" :errors="errors" />
+    <div class="layer-container" :style="{ '--layer-color': unref(color) }" v-bind="$attrs" v-else>
         <button v-if="showGoBack" class="goBack" @click="goBack">❌</button>
 
         <button
@@ -28,12 +29,12 @@ import type { CoercableComponent } from "features/feature";
 import type { FeatureNode } from "game/layers";
 import player from "game/player";
 import { computeComponent, computeOptionalComponent, processedPropType, unwrapRef } from "util/vue";
-import type { PropType, Ref } from "vue";
-import { computed, defineComponent, toRefs, unref } from "vue";
+import { PropType, Ref, computed, defineComponent, onErrorCaptured, ref, toRefs, unref } from "vue";
 import Context from "./Context.vue";
+import ErrorVue from "./Error.vue";
 
 export default defineComponent({
-    components: { Context },
+    components: { Context, ErrorVue },
     props: {
         index: {
             type: Number,
@@ -77,13 +78,23 @@ export default defineComponent({
             props.nodes.value = nodes;
         }
 
+        const errors = ref<Error[]>([]);
+        onErrorCaptured((err, instance, info) => {
+            console.warn(`Error caught in "${props.name}" layer`, err, instance, info);
+            errors.value.push(
+                err instanceof Error ? (err as Error) : new Error(JSON.stringify(err))
+            );
+            return false;
+        });
+
         return {
             component,
             minimizedComponent,
             showGoBack,
             updateNodes,
             unref,
-            goBack
+            goBack,
+            errors
         };
     }
 });

--- a/src/data/common.tsx
+++ b/src/data/common.tsx
@@ -459,7 +459,7 @@ export function createFormulaPreview(
     const processedShowPreview = convertComputable(showPreview);
     const processedPreviewAmount = convertComputable(previewAmount);
     if (!formula.hasVariable()) {
-        throw new Error("Cannot create formula preview if the formula does not have a variable");
+        console.error("Cannot create formula preview if the formula does not have a variable");
     }
     return jsx(() => {
         if (unref(processedShowPreview)) {

--- a/src/features/challenges/challenge.tsx
+++ b/src/features/challenges/challenge.tsx
@@ -52,8 +52,6 @@ export interface ChallengeOptions {
     reset?: GenericReset;
     /** The requirement(s) to complete this challenge. */
     requirements: Requirements;
-    /** Whether or not completing this challenge should grant multiple completions if requirements met. Requires {@link requirements} to be a requirement or array of requirements with {@link Requirement.canMaximize} true. */
-    maximize?: Computable<boolean>;
     /** The maximum number of times the challenge can be completed. */
     completionLimit?: Computable<DecimalSource>;
     /** Shows a marker on the corner of the feature. */
@@ -124,7 +122,6 @@ export type Challenge<T extends ChallengeOptions> = Replace<
         visibility: GetComputableTypeWithDefault<T["visibility"], Visibility.Visible>;
         canStart: GetComputableTypeWithDefault<T["canStart"], true>;
         requirements: GetComputableType<T["requirements"]>;
-        maximize: GetComputableType<T["maximize"]>;
         completionLimit: GetComputableTypeWithDefault<T["completionLimit"], 1>;
         mark: GetComputableTypeWithDefault<T["mark"], Ref<boolean>>;
         classes: GetComputableType<T["classes"]>;
@@ -210,10 +207,7 @@ export function createChallenge<T extends ChallengeOptions>(
             }
         };
         challenge.canComplete = computed(() =>
-            Decimal.max(
-                maxRequirementsMet((challenge as GenericChallenge).requirements),
-                unref((challenge as GenericChallenge).maximize) ? Decimal.dInf : 1
-            )
+            maxRequirementsMet((challenge as GenericChallenge).requirements)
         );
         challenge.complete = function (remainInChallenge?: boolean) {
             const genericChallenge = challenge as GenericChallenge;
@@ -254,7 +248,6 @@ export function createChallenge<T extends ChallengeOptions>(
 
         processComputable(challenge as T, "canStart");
         setDefault(challenge, "canStart", true);
-        processComputable(challenge as T, "maximize");
         processComputable(challenge as T, "completionLimit");
         setDefault(challenge, "completionLimit", 1);
         processComputable(challenge as T, "mark");

--- a/src/features/repeatable.tsx
+++ b/src/features/repeatable.tsx
@@ -67,8 +67,6 @@ export interface RepeatableOptions {
     mark?: Computable<boolean | string>;
     /** Toggles a smaller design for the feature. */
     small?: Computable<boolean>;
-    /** Whether or not clicking this repeatable should attempt to maximize amount based on the requirements met. Requires {@link requirements} to be a requirement or array of requirements with {@link Requirement.canMaximize} true. */
-    maximize?: Computable<boolean>;
     /** The display to use for this repeatable. */
     display?: Computable<RepeatableDisplay>;
 }
@@ -87,7 +85,6 @@ export interface BaseRepeatable {
     canClick: ProcessedComputable<boolean>;
     /**
      * How much amount can be increased by, or 1 if unclickable.
-     * Capped at 1 if {@link RepeatableOptions.maximize} is false.
      **/
     amountToIncrease: Ref<DecimalSource>;
     /** A function that gets called when this repeatable is clicked. */
@@ -111,7 +108,6 @@ export type Repeatable<T extends RepeatableOptions> = Replace<
         style: GetComputableType<T["style"]>;
         mark: GetComputableType<T["mark"]>;
         small: GetComputableType<T["small"]>;
-        maximize: GetComputableType<T["maximize"]>;
         display: Ref<CoercableComponent>;
     }
 >;
@@ -195,9 +191,7 @@ export function createRepeatable<T extends RepeatableOptions>(
             return currClasses;
         });
         repeatable.amountToIncrease = computed(() =>
-            unref((repeatable as GenericRepeatable).maximize)
-                ? maxRequirementsMet(repeatable.requirements)
-                : 1
+            Decimal.clampMin(maxRequirementsMet(repeatable.requirements), 1)
         );
         repeatable.canClick = computed(() => requirementsMet(repeatable.requirements));
         const onClick = repeatable.onClick;
@@ -274,7 +268,6 @@ export function createRepeatable<T extends RepeatableOptions>(
         processComputable(repeatable as T, "style");
         processComputable(repeatable as T, "mark");
         processComputable(repeatable as T, "small");
-        processComputable(repeatable as T, "maximize");
 
         for (const decorator of decorators) {
             decorator.postConstruct?.(repeatable);

--- a/src/features/tabs/tabFamily.ts
+++ b/src/features/tabs/tabFamily.ts
@@ -151,8 +151,7 @@ export function createTabFamily<T extends TabFamilyOptions>(
     optionsFunc?: OptionsFunc<T, BaseTabFamily, GenericTabFamily>
 ): TabFamily<T> {
     if (Object.keys(tabs).length === 0) {
-        console.warn("Cannot create tab family with 0 tabs");
-        throw new Error("Cannot create tab family with 0 tabs");
+        console.error("Cannot create tab family with 0 tabs");
     }
 
     const selected = persistent(Object.keys(tabs)[0], false);

--- a/src/game/formulas/formulas.ts
+++ b/src/game/formulas/formulas.ts
@@ -1344,6 +1344,7 @@ export default class Formula<
             // "Inner" part of the formula
             if (this.applySubstitution == null) {
                 console.error("Cannot have two complex operations in an integrable formula");
+                return Formula.constant(0);
             }
             stack.push((variable: GenericFormula) =>
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/src/game/formulas/formulas.ts
+++ b/src/game/formulas/formulas.ts
@@ -2,7 +2,7 @@ import { Resource } from "features/resources/resource";
 import { NonPersistent } from "game/persistence";
 import Decimal, { DecimalSource, format } from "util/bignum";
 import { Computable, ProcessedComputable, convertComputable } from "util/computed";
-import { ComputedRef, Ref, computed, ref, unref } from "vue";
+import { Ref, computed, ref, unref } from "vue";
 import * as ops from "./operations";
 import type {
     EvaluateFunction,
@@ -104,7 +104,7 @@ export abstract class InternalFormula<T extends [FormulaSource] | FormulaSource[
 
     private setupConstant({ inputs }: { inputs: [FormulaSource] }): InternalFormulaProperties<T> {
         if (inputs.length !== 1) {
-            throw new Error("Evaluate function is required if inputs is not length 1");
+            console.error("Evaluate function is required if inputs is not length 1");
         }
         return {
             inputs: inputs as T,
@@ -250,7 +250,8 @@ export abstract class InternalFormula<T extends [FormulaSource] | FormulaSource[
                 }
                 return lhs.invert(value);
             }
-            throw new Error("Could not invert due to no input being a variable");
+            console.error("Could not invert due to no input being a variable");
+            return 0;
         }
         return new Formula({
             inputs: [value],
@@ -294,7 +295,8 @@ export abstract class InternalFormula<T extends [FormulaSource] | FormulaSource[
                 !formula.isInvertible() ||
                 (elseFormula != null && !elseFormula.isInvertible())
             ) {
-                throw new Error("Could not invert due to no input being a variable");
+                console.error("Could not invert due to no input being a variable");
+                return 0;
             }
             if (unref(processedCondition)) {
                 return lhs.invert(formula.invert(value));
@@ -1260,7 +1262,8 @@ export default class Formula<
         } else if (this.inputs.length === 1 && this.hasVariable()) {
             return value;
         }
-        throw new Error("Cannot invert non-invertible formula");
+        console.error("Cannot invert non-invertible formula");
+        return 0;
     }
 
     /**
@@ -1270,7 +1273,8 @@ export default class Formula<
      */
     evaluateIntegral(variable?: DecimalSource): DecimalSource {
         if (!this.isIntegrable()) {
-            throw new Error("Cannot evaluate integral of formula without integral");
+            console.error("Cannot evaluate integral of formula without integral");
+            return 0;
         }
         return this.getIntegralFormula().evaluate(variable);
     }
@@ -1282,7 +1286,8 @@ export default class Formula<
      */
     invertIntegral(value: DecimalSource): DecimalSource {
         if (!this.isIntegrable() || !this.getIntegralFormula().isInvertible()) {
-            throw new Error("Cannot invert integral of formula without invertible integral");
+            console.error("Cannot invert integral of formula without invertible integral");
+            return 0;
         }
         return (this.getIntegralFormula() as InvertibleFormula).invert(value);
     }
@@ -1309,7 +1314,8 @@ export default class Formula<
                 // We're the complex operation of this formula
                 stack = [];
                 if (this.internalIntegrate == null) {
-                    throw new Error("Cannot integrate formula with non-integrable operation");
+                    console.error("Cannot integrate formula with non-integrable operation");
+                    return Formula.constant(0);
                 }
                 let value = this.internalIntegrate.call(this, stack, ...this.inputs);
                 stack.forEach(func => (value = func(value)));
@@ -1329,14 +1335,15 @@ export default class Formula<
                 ) {
                     this.integralFormula = this;
                 } else {
-                    throw new Error("Cannot integrate formula without variable");
+                    console.error("Cannot integrate formula without variable");
+                    return Formula.constant(0);
                 }
             }
             return this.integralFormula;
         } else {
             // "Inner" part of the formula
             if (this.applySubstitution == null) {
-                throw new Error("Cannot have two complex operations in an integrable formula");
+                console.error("Cannot have two complex operations in an integrable formula");
             }
             stack.push((variable: GenericFormula) =>
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -1353,7 +1360,8 @@ export default class Formula<
             ) {
                 return this;
             } else {
-                throw new Error("Cannot integrate formula without variable");
+                console.error("Cannot integrate formula without variable");
+                return Formula.constant(0);
             }
         }
     }
@@ -1428,15 +1436,17 @@ export function calculateMaxAffordable(
         let affordable: DecimalSource = 0;
         if (Decimal.gt(maxBulkAmount, directSum)) {
             if (!formula.isInvertible()) {
-                throw new Error(
+                console.error(
                     "Cannot calculate max affordable of non-invertible formula with more maxBulkAmount than directSum"
                 );
+                return 0;
             }
             if (cumulativeCost) {
                 if (!formula.isIntegralInvertible()) {
-                    throw new Error(
+                    console.error(
                         "Cannot calculate max affordable of formula with non-invertible integral"
                     );
+                    return 0;
                 }
                 affordable = Decimal.floor(
                     formula.invertIntegral(Decimal.add(resource.value, formula.evaluateIntegral()))
@@ -1517,13 +1527,15 @@ export function calculateCost(
     // Indirect sum
     if (Decimal.gt(amountToBuy, directSum)) {
         if (!formula.isInvertible()) {
-            throw new Error("Cannot calculate cost with indirect sum of non-invertible formula");
+            console.error("Cannot calculate cost with indirect sum of non-invertible formula");
+            return 0;
         }
         if (cumulativeCost) {
             if (!formula.isIntegrable()) {
-                throw new Error(
+                console.error(
                     "Cannot calculate cost with cumulative cost of non-integrable formula"
                 );
+                return 0;
             }
             cost = Decimal.sub(formula.evaluateIntegral(newValue), formula.evaluateIntegral());
             if (targetValue.gt(1e308)) {

--- a/src/game/formulas/formulas.ts
+++ b/src/game/formulas/formulas.ts
@@ -1447,6 +1447,7 @@ export function calculateMaxAffordable(
         }
         affordable = Decimal.clampMax(affordable, maxBulkAmount);
         if (directSum > 0) {
+            const preSumAffordable = affordable;
             affordable = Decimal.sub(affordable, directSum).clampMin(0);
             let summedCost;
             if (cumulativeCost) {
@@ -1458,7 +1459,8 @@ export function calculateMaxAffordable(
             }
             while (
                 Decimal.lt(affordable, maxBulkAmount) &&
-                Decimal.lt(affordable, Number.MAX_SAFE_INTEGER)
+                Decimal.lt(affordable, Number.MAX_SAFE_INTEGER) &&
+                Decimal.add(preSumAffordable, 1).gte(affordable)
             ) {
                 const nextCost = formula.evaluate(
                     affordable.add(unref(formula.innermostVariable) ?? 0)

--- a/src/game/formulas/operations.ts
+++ b/src/game/formulas/operations.ts
@@ -12,17 +12,20 @@ export function invertNeg(value: DecimalSource, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         return lhs.invert(Decimal.neg(value));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function integrateNeg(stack: SubstitutionStack, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         return Formula.neg(lhs.getIntegralFormula(stack));
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function applySubstitutionNeg(value: GenericFormula) {
@@ -35,24 +38,28 @@ export function invertAdd(value: DecimalSource, lhs: FormulaSource, rhs: Formula
     } else if (hasVariable(rhs)) {
         return rhs.invert(Decimal.sub(value, unrefFormulaSource(lhs)));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function integrateAdd(stack: SubstitutionStack, lhs: FormulaSource, rhs: FormulaSource) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = lhs.getIntegralFormula(stack);
         return Formula.times(rhs, lhs.innermostVariable ?? 0).add(x);
     } else if (hasVariable(rhs)) {
         if (!rhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = rhs.getIntegralFormula(stack);
         return Formula.times(lhs, rhs.innermostVariable ?? 0).add(x);
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function integrateInnerAdd(
@@ -62,18 +69,21 @@ export function integrateInnerAdd(
 ) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = lhs.getIntegralFormula(stack);
         return Formula.add(x, rhs);
     } else if (hasVariable(rhs)) {
         if (!rhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = rhs.getIntegralFormula(stack);
         return Formula.add(x, lhs);
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function invertSub(value: DecimalSource, lhs: FormulaSource, rhs: FormulaSource) {
@@ -82,24 +92,28 @@ export function invertSub(value: DecimalSource, lhs: FormulaSource, rhs: Formula
     } else if (hasVariable(rhs)) {
         return rhs.invert(Decimal.sub(unrefFormulaSource(lhs), value));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function integrateSub(stack: SubstitutionStack, lhs: FormulaSource, rhs: FormulaSource) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = lhs.getIntegralFormula(stack);
         return Formula.sub(x, Formula.times(rhs, lhs.innermostVariable ?? 0));
     } else if (hasVariable(rhs)) {
         if (!rhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = rhs.getIntegralFormula(stack);
         return Formula.times(lhs, rhs.innermostVariable ?? 0).sub(x);
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function integrateInnerSub(
@@ -109,18 +123,21 @@ export function integrateInnerSub(
 ) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = lhs.getIntegralFormula(stack);
         return Formula.sub(x, rhs);
     } else if (hasVariable(rhs)) {
         if (!rhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = rhs.getIntegralFormula(stack);
         return Formula.sub(x, lhs);
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function invertMul(value: DecimalSource, lhs: FormulaSource, rhs: FormulaSource) {
@@ -129,24 +146,28 @@ export function invertMul(value: DecimalSource, lhs: FormulaSource, rhs: Formula
     } else if (hasVariable(rhs)) {
         return rhs.invert(Decimal.div(value, unrefFormulaSource(lhs)));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function integrateMul(stack: SubstitutionStack, lhs: FormulaSource, rhs: FormulaSource) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = lhs.getIntegralFormula(stack);
         return Formula.times(x, rhs);
     } else if (hasVariable(rhs)) {
         if (!rhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = rhs.getIntegralFormula(stack);
         return Formula.times(x, lhs);
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function applySubstitutionMul(
@@ -159,7 +180,8 @@ export function applySubstitutionMul(
     } else if (hasVariable(rhs)) {
         return Formula.div(value, lhs);
     }
-    throw new Error("Could not apply substitution due to no input being a variable");
+    console.error("Could not apply substitution due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function invertDiv(value: DecimalSource, lhs: FormulaSource, rhs: FormulaSource) {
@@ -168,24 +190,28 @@ export function invertDiv(value: DecimalSource, lhs: FormulaSource, rhs: Formula
     } else if (hasVariable(rhs)) {
         return rhs.invert(Decimal.div(unrefFormulaSource(lhs), value));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function integrateDiv(stack: SubstitutionStack, lhs: FormulaSource, rhs: FormulaSource) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = lhs.getIntegralFormula(stack);
         return Formula.div(x, rhs);
     } else if (hasVariable(rhs)) {
         if (!rhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = rhs.getIntegralFormula(stack);
         return Formula.div(lhs, x);
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function applySubstitutionDiv(
@@ -198,32 +224,37 @@ export function applySubstitutionDiv(
     } else if (hasVariable(rhs)) {
         return Formula.mul(value, lhs);
     }
-    throw new Error("Could not apply substitution due to no input being a variable");
+    console.error("Could not apply substitution due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function invertRecip(value: DecimalSource, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         return lhs.invert(Decimal.recip(value));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function integrateRecip(stack: SubstitutionStack, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = lhs.getIntegralFormula(stack);
         return Formula.ln(x);
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function invertLog10(value: DecimalSource, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         return lhs.invert(Decimal.pow10(value));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 function internalIntegrateLog10(lhs: DecimalSource) {
@@ -235,13 +266,15 @@ function internalInvertIntegralLog10(value: DecimalSource, lhs: FormulaSource) {
         const numerator = ln10.times(value);
         return lhs.invert(numerator.div(numerator.div(Math.E).lambertw()));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function integrateLog10(stack: SubstitutionStack, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         return new Formula({
             inputs: [lhs.getIntegralFormula(stack)],
@@ -249,7 +282,8 @@ export function integrateLog10(stack: SubstitutionStack, lhs: FormulaSource) {
             invert: internalInvertIntegralLog10
         });
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function invertLog(value: DecimalSource, lhs: FormulaSource, rhs: FormulaSource) {
@@ -258,7 +292,8 @@ export function invertLog(value: DecimalSource, lhs: FormulaSource, rhs: Formula
     } else if (hasVariable(rhs)) {
         return rhs.invert(Decimal.root(unrefFormulaSource(lhs), value));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 function internalIntegrateLog(lhs: DecimalSource, rhs: DecimalSource) {
@@ -270,13 +305,15 @@ function internalInvertIntegralLog(value: DecimalSource, lhs: FormulaSource, rhs
         const numerator = Decimal.ln(unrefFormulaSource(rhs)).times(value);
         return lhs.invert(numerator.div(numerator.div(Math.E).lambertw()));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function integrateLog(stack: SubstitutionStack, lhs: FormulaSource, rhs: FormulaSource) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         return new Formula({
             inputs: [lhs.getIntegralFormula(stack), rhs],
@@ -284,14 +321,16 @@ export function integrateLog(stack: SubstitutionStack, lhs: FormulaSource, rhs: 
             invert: internalInvertIntegralLog
         });
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function invertLog2(value: DecimalSource, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         return lhs.invert(Decimal.pow(2, value));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 function internalIntegrateLog2(lhs: DecimalSource) {
@@ -303,13 +342,15 @@ function internalInvertIntegralLog2(value: DecimalSource, lhs: FormulaSource) {
         const numerator = Decimal.ln(2).times(value);
         return lhs.invert(numerator.div(numerator.div(Math.E).lambertw()));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function integrateLog2(stack: SubstitutionStack, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         return new Formula({
             inputs: [lhs.getIntegralFormula(stack)],
@@ -317,14 +358,16 @@ export function integrateLog2(stack: SubstitutionStack, lhs: FormulaSource) {
             invert: internalInvertIntegralLog2
         });
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function invertLn(value: DecimalSource, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         return lhs.invert(Decimal.exp(value));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 function internalIntegrateLn(lhs: DecimalSource) {
@@ -335,13 +378,15 @@ function internalInvertIntegralLn(value: DecimalSource, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         return lhs.invert(Decimal.div(value, Decimal.div(value, Math.E).lambertw()));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function integrateLn(stack: SubstitutionStack, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         return new Formula({
             inputs: [lhs.getIntegralFormula(stack)],
@@ -349,7 +394,8 @@ export function integrateLn(stack: SubstitutionStack, lhs: FormulaSource) {
             invert: internalInvertIntegralLn
         });
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function invertPow(value: DecimalSource, lhs: FormulaSource, rhs: FormulaSource) {
@@ -358,43 +404,50 @@ export function invertPow(value: DecimalSource, lhs: FormulaSource, rhs: Formula
     } else if (hasVariable(rhs)) {
         return rhs.invert(Decimal.ln(value).div(Decimal.ln(unrefFormulaSource(lhs))));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function integratePow(stack: SubstitutionStack, lhs: FormulaSource, rhs: FormulaSource) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = lhs.getIntegralFormula(stack);
         const pow = Formula.add(rhs, 1);
         return Formula.pow(x, pow).div(pow);
     } else if (hasVariable(rhs)) {
         if (!rhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = rhs.getIntegralFormula(stack);
         return Formula.pow(lhs, x).div(Formula.ln(lhs));
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function invertPow10(value: DecimalSource, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         return lhs.invert(Decimal.root(value, 10));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function integratePow10(stack: SubstitutionStack, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = lhs.getIntegralFormula(stack);
         return Formula.pow10(x).div(Formula.ln(10));
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function invertPowBase(value: DecimalSource, lhs: FormulaSource, rhs: FormulaSource) {
@@ -403,25 +456,29 @@ export function invertPowBase(value: DecimalSource, lhs: FormulaSource, rhs: For
     } else if (hasVariable(rhs)) {
         return rhs.invert(Decimal.root(unrefFormulaSource(lhs), value));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function integratePowBase(stack: SubstitutionStack, lhs: FormulaSource, rhs: FormulaSource) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = lhs.getIntegralFormula(stack);
         return Formula.pow(rhs, x).div(Formula.ln(rhs));
     } else if (hasVariable(rhs)) {
         if (!rhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = rhs.getIntegralFormula(stack);
         const denominator = Formula.add(lhs, 1);
         return Formula.pow(x, denominator).div(denominator);
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function invertRoot(value: DecimalSource, lhs: FormulaSource, rhs: FormulaSource) {
@@ -430,36 +487,42 @@ export function invertRoot(value: DecimalSource, lhs: FormulaSource, rhs: Formul
     } else if (hasVariable(rhs)) {
         return rhs.invert(Decimal.ln(unrefFormulaSource(lhs)).div(Decimal.ln(value)));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function integrateRoot(stack: SubstitutionStack, lhs: FormulaSource, rhs: FormulaSource) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = lhs.getIntegralFormula(stack);
         return Formula.pow(x, Formula.recip(rhs).add(1)).times(rhs).div(Formula.add(rhs, 1));
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function invertExp(value: DecimalSource, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         return lhs.invert(Decimal.ln(value));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function integrateExp(stack: SubstitutionStack, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = lhs.getIntegralFormula(stack);
         return Formula.exp(x);
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function tetrate(
@@ -481,7 +544,8 @@ export function invertTetrate(
         return base.invert(Decimal.ssqrt(value));
     }
     // Other params can't be inverted ATM
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function iteratedexp(
@@ -509,7 +573,8 @@ export function invertIteratedExp(
         );
     }
     // Other params can't be inverted ATM
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function iteratedLog(
@@ -533,7 +598,8 @@ export function invertSlog(value: DecimalSource, lhs: FormulaSource, rhs: Formul
         );
     }
     // Other params can't be inverted ATM
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function layeradd(value: DecimalSource, diff: DecimalSource, base: DecimalSource) {
@@ -556,21 +622,24 @@ export function invertLayeradd(
         );
     }
     // Other params can't be inverted ATM
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function invertLambertw(value: DecimalSource, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         return lhs.invert(Decimal.pow(Math.E, value).times(value));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function invertSsqrt(value: DecimalSource, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         return lhs.invert(Decimal.tetrate(value, 2));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function pentate(value: DecimalSource, height: DecimalSource, payload: DecimalSource) {
@@ -582,226 +651,262 @@ export function invertSin(value: DecimalSource, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         return lhs.invert(Decimal.asin(value));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function integrateSin(stack: SubstitutionStack, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = lhs.getIntegralFormula(stack);
         return Formula.cos(x).neg();
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function invertCos(value: DecimalSource, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         return lhs.invert(Decimal.acos(value));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function integrateCos(stack: SubstitutionStack, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = lhs.getIntegralFormula(stack);
         return Formula.sin(x);
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function invertTan(value: DecimalSource, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         return lhs.invert(Decimal.atan(value));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function integrateTan(stack: SubstitutionStack, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = lhs.getIntegralFormula(stack);
         return Formula.cos(x).ln().neg();
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function invertAsin(value: DecimalSource, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         return lhs.invert(Decimal.sin(value));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function integrateAsin(stack: SubstitutionStack, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = lhs.getIntegralFormula(stack);
         return Formula.asin(x)
             .times(x)
             .add(Formula.sqrt(Formula.sub(1, Formula.pow(x, 2))));
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function invertAcos(value: DecimalSource, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         return lhs.invert(Decimal.cos(value));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function integrateAcos(stack: SubstitutionStack, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = lhs.getIntegralFormula(stack);
         return Formula.acos(x)
             .times(x)
             .sub(Formula.sqrt(Formula.sub(1, Formula.pow(x, 2))));
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function invertAtan(value: DecimalSource, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         return lhs.invert(Decimal.tan(value));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function integrateAtan(stack: SubstitutionStack, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = lhs.getIntegralFormula(stack);
         return Formula.atan(x)
             .times(x)
             .sub(Formula.ln(Formula.pow(x, 2).add(1)).div(2));
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function invertSinh(value: DecimalSource, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         return lhs.invert(Decimal.asinh(value));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function integrateSinh(stack: SubstitutionStack, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = lhs.getIntegralFormula(stack);
         return Formula.cosh(x);
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function invertCosh(value: DecimalSource, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         return lhs.invert(Decimal.acosh(value));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function integrateCosh(stack: SubstitutionStack, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = lhs.getIntegralFormula(stack);
         return Formula.sinh(x);
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function invertTanh(value: DecimalSource, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         return lhs.invert(Decimal.atanh(value));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function integrateTanh(stack: SubstitutionStack, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = lhs.getIntegralFormula(stack);
         return Formula.cosh(x).ln();
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function invertAsinh(value: DecimalSource, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         return lhs.invert(Decimal.sinh(value));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function integrateAsinh(stack: SubstitutionStack, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = lhs.getIntegralFormula(stack);
         return Formula.asinh(x).times(x).sub(Formula.pow(x, 2).add(1).sqrt());
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function invertAcosh(value: DecimalSource, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         return lhs.invert(Decimal.cosh(value));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function integrateAcosh(stack: SubstitutionStack, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = lhs.getIntegralFormula(stack);
         return Formula.acosh(x)
             .times(x)
             .sub(Formula.add(x, 1).sqrt().times(Formula.sub(x, 1).sqrt()));
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function invertAtanh(value: DecimalSource, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         return lhs.invert(Decimal.tanh(value));
     }
-    throw new Error("Could not invert due to no input being a variable");
+    console.error("Could not invert due to no input being a variable");
+    return 0;
 }
 
 export function integrateAtanh(stack: SubstitutionStack, lhs: FormulaSource) {
     if (hasVariable(lhs)) {
         if (!lhs.isIntegrable()) {
-            throw new Error("Could not integrate due to variable not being integrable");
+            console.error("Could not integrate due to variable not being integrable");
+            return Formula.constant(0);
         }
         const x = lhs.getIntegralFormula(stack);
         return Formula.atanh(x)
             .times(x)
             .add(Formula.sub(1, Formula.pow(x, 2)).ln().div(2));
     }
-    throw new Error("Could not integrate due to no input being a variable");
+    console.error("Could not integrate due to no input being a variable");
+    return Formula.constant(0);
 }
 
 export function createPassthroughBinaryFormula(

--- a/src/game/formulas/operations.ts
+++ b/src/game/formulas/operations.ts
@@ -399,7 +399,7 @@ export function integratePow10(stack: SubstitutionStack, lhs: FormulaSource) {
 
 export function invertPowBase(value: DecimalSource, lhs: FormulaSource, rhs: FormulaSource) {
     if (hasVariable(lhs)) {
-        return lhs.invert(Decimal.ln(value).div(unrefFormulaSource(rhs)));
+        return lhs.invert(Decimal.ln(value).div(Decimal.ln(unrefFormulaSource(rhs))));
     } else if (hasVariable(rhs)) {
         return rhs.invert(Decimal.root(unrefFormulaSource(lhs), value));
     }

--- a/src/game/layers.tsx
+++ b/src/game/layers.tsx
@@ -225,7 +225,9 @@ export function createLayer<T extends LayerOptions>(
             addingLayers[addingLayers.length - 1] == null ||
             addingLayers[addingLayers.length - 1] !== id
         ) {
-            throw `Adding layers stack in invalid state. This should not happen\nStack: ${addingLayers}\nTrying to pop ${layer.id}`;
+            throw new Error(
+                `Adding layers stack in invalid state. This should not happen\nStack: ${addingLayers}\nTrying to pop ${layer.id}`
+            );
         }
         addingLayers.pop();
 

--- a/src/game/persistence.ts
+++ b/src/game/persistence.ts
@@ -116,12 +116,7 @@ function checkNaNAndWrite<T extends State>(persistent: Persistent<T>, value: T) 
             state.NaNPath = persistent[SaveDataPath];
             state.NaNPersistent = persistent as Persistent<DecimalSource>;
         }
-        console.error(
-            `Attempted to save NaN value to`,
-            persistent[SaveDataPath]?.join("."),
-            persistent
-        );
-        throw new Error("Attempted to set NaN value. See above for details");
+        console.error(`Attempted to save NaN value to ${persistent[SaveDataPath]?.join(".")}`);
     }
     persistent[PersistentState].value = value;
 }
@@ -292,8 +287,8 @@ globalBus.on("addLayer", (layer: GenericLayer, saveData: Record<string, unknown>
                                 "."
                             )}\` when it's already present at \`${value[SaveDataPath].join(
                                 "."
-                            )}\`. This can cause unexpected behavior when loading saves between updates.`,
-                            value
+                            )}\`.`,
+                            "This can cause unexpected behavior when loading saves between updates."
                         );
                     }
                     value[SaveDataPath] = newPath;
@@ -368,9 +363,9 @@ globalBus.on("addLayer", (layer: GenericLayer, saveData: Record<string, unknown>
             return;
         }
         console.error(
-            `Created persistent ref in ${layer.id} without registering it to the layer! Make sure to include everything persistent in the returned object`,
-            persistent,
-            "\nCreated at:\n" + persistent[StackTrace]
+            `Created persistent ref in ${layer.id} without registering it to the layer!`,
+            "Make sure to include everything persistent in the returned object.\n\nCreated at:\n" +
+                persistent[StackTrace]
         );
     });
     persistentRefs[layer.id].clear();

--- a/src/game/requirements.tsx
+++ b/src/game/requirements.tsx
@@ -20,7 +20,7 @@ import { createLazyProxy } from "util/proxies";
 import { joinJSX, renderJSX } from "util/vue";
 import { computed, unref } from "vue";
 import Formula, { calculateCost, calculateMaxAffordable } from "./formulas/formulas";
-import type { GenericFormula, InvertibleFormula } from "./formulas/types";
+import type { GenericFormula } from "./formulas/types";
 import { DefaultValue, Persistent } from "./persistence";
 
 /**
@@ -86,7 +86,15 @@ export interface CostRequirementOptions {
      * When calculating multiple levels to be handled at once, whether it should consider resources used for each level as spent. Setting this to false causes calculations to be faster with larger numbers and supports more math functions.
      * @see {Formula}
      */
-    spendResources?: Computable<boolean>;
+    cumulativeCost?: Computable<boolean>;
+    /**
+     * Upper limit on levels that can be performed at once. Defaults to 1.
+     */
+    maxBulkAmount?: Computable<DecimalSource>;
+    /**
+     * When calculating requirement for multiple levels, how many should be directly summed for increase accuracy. High numbers can cause lag. Defaults to 10 if cumulative cost, 0 otherwise.
+     */
+    directSum?: Computable<number>;
     /**
      * Pass-through to {@link Requirement.pay}. May be required for maximizing support.
      * @see {@link cost} for restrictions on maximizing support.
@@ -100,7 +108,7 @@ export type CostRequirement = Replace<
         cost: ProcessedComputable<DecimalSource> | GenericFormula;
         visibility: ProcessedComputable<Visibility.Visible | Visibility.None | boolean>;
         requiresPay: ProcessedComputable<boolean>;
-        spendResources: ProcessedComputable<boolean>;
+        cumulativeCost: ProcessedComputable<boolean>;
         canMaximize: ProcessedComputable<boolean>;
     }
 >;
@@ -126,7 +134,12 @@ export function createCostRequirement<T extends CostRequirementOptions>(
                 {displayResource(
                     req.resource,
                     req.cost instanceof Formula
-                        ? calculateCost(req.cost, amount ?? 1, unref(req.spendResources) as boolean)
+                        ? calculateCost(
+                              req.cost,
+                              amount ?? 1,
+                              unref(req.cumulativeCost) as boolean,
+                              unref(req.directSum) as number
+                          )
                         : unref(req.cost as ProcessedComputable<DecimalSource>)
                 )}{" "}
                 {req.resource.displayName}
@@ -138,7 +151,12 @@ export function createCostRequirement<T extends CostRequirementOptions>(
                 {displayResource(
                     req.resource,
                     req.cost instanceof Formula
-                        ? calculateCost(req.cost, amount ?? 1, unref(req.spendResources) as boolean)
+                        ? calculateCost(
+                              req.cost,
+                              amount ?? 1,
+                              unref(req.cumulativeCost) as boolean,
+                              unref(req.directSum) as number
+                          )
                         : unref(req.cost as ProcessedComputable<DecimalSource>)
                 )}{" "}
                 {req.resource.displayName}
@@ -150,54 +168,62 @@ export function createCostRequirement<T extends CostRequirementOptions>(
         processComputable(req as T, "cost");
         processComputable(req as T, "requiresPay");
         setDefault(req, "requiresPay", true);
-        processComputable(req as T, "spendResources");
-        setDefault(req, "spendResources", true);
+        processComputable(req as T, "cumulativeCost");
+        setDefault(req, "cumulativeCost", true);
+        processComputable(req as T, "maxBulkAmount");
+        setDefault(req, "maxBulkAmount", 1);
+        processComputable(req as T, "directSum");
         setDefault(req, "pay", function (amount?: DecimalSource) {
             const cost =
                 req.cost instanceof Formula
-                    ? calculateCost(req.cost, amount ?? 1, unref(req.spendResources) as boolean)
+                    ? calculateCost(
+                          req.cost,
+                          amount ?? 1,
+                          unref(req.cumulativeCost) as boolean,
+                          unref(req.directSum) as number
+                      )
                     : unref(req.cost as ProcessedComputable<DecimalSource>);
             req.resource.value = Decimal.sub(req.resource.value, cost).max(0);
         });
 
-        req.canMaximize = computed(
-            () =>
-                req.cost instanceof Formula &&
-                req.cost.isInvertible() &&
-                (unref(req.spendResources) === false || req.cost.isIntegrable())
-        );
+        req.canMaximize = computed(() => {
+            if (!(req.cost instanceof Formula)) {
+                return false;
+            }
+            const maxBulkAmount = unref(req.maxBulkAmount as ProcessedComputable<DecimalSource>);
+            if (Decimal.lte(maxBulkAmount, 1)) {
+                return false;
+            }
+            const cumulativeCost = unref(req.cumulativeCost as ProcessedComputable<boolean>);
+            const directSum =
+                unref(req.directSum as ProcessedComputable<number>) ?? (cumulativeCost ? 10 : 0);
+            if (Decimal.lte(maxBulkAmount, directSum)) {
+                return true;
+            }
+            if (!req.cost.isInvertible()) {
+                return false;
+            }
+            if (cumulativeCost === true && !req.cost.isIntegrable()) {
+                return false;
+            }
+            return true;
+        });
 
-        if (req.cost instanceof Formula && req.cost.isInvertible()) {
-            const maxAffordable = calculateMaxAffordable(
+        if (req.cost instanceof Formula) {
+            req.requirementMet = calculateMaxAffordable(
                 req.cost,
                 req.resource,
-                unref(req.spendResources) as boolean
+                req.cumulativeCost ?? true,
+                req.directSum,
+                req.maxBulkAmount
             );
-            req.requirementMet = computed(() => {
-                if (unref(req.canMaximize)) {
-                    return maxAffordable.value;
-                } else {
-                    if (req.cost instanceof Formula) {
-                        return Decimal.gte(req.resource.value, req.cost.evaluate());
-                    } else {
-                        return Decimal.gte(
-                            req.resource.value,
-                            unref(req.cost as ProcessedComputable<DecimalSource>)
-                        );
-                    }
-                }
-            });
         } else {
-            req.requirementMet = computed(() => {
-                if (req.cost instanceof Formula) {
-                    return Decimal.gte(req.resource.value, req.cost.evaluate());
-                } else {
-                    return Decimal.gte(
-                        req.resource.value,
-                        unref(req.cost as ProcessedComputable<DecimalSource>)
-                    );
-                }
-            });
+            req.requirementMet = computed(() =>
+                Decimal.gte(
+                    req.resource.value,
+                    unref(req.cost as ProcessedComputable<DecimalSource>)
+                )
+            );
         }
 
         return req as CostRequirement;
@@ -328,7 +354,7 @@ export function payByDivision(this: CostRequirement, amount?: DecimalSource) {
             ? calculateCost(
                   this.cost,
                   amount ?? 1,
-                  unref(this.spendResources as ProcessedComputable<boolean> | undefined) ?? true
+                  unref(this.cumulativeCost as ProcessedComputable<boolean> | undefined) ?? true
               )
             : unref(this.cost as ProcessedComputable<DecimalSource>);
     this.resource.value = Decimal.div(this.resource.value, cost);

--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -1,5 +1,5 @@
 import type { DecimalSource } from "util/bignum";
-import { shallowReactive } from "vue";
+import { reactive, shallowReactive } from "vue";
 import type { Persistent } from "./persistence";
 
 /** An object of global data that is not persistent. */
@@ -12,6 +12,8 @@ export interface Transient {
     NaNPath?: string[];
     /** The ref that was being set to NaN. */
     NaNPersistent?: Persistent<DecimalSource>;
+    /** List of errors that have occurred, to show the user. */
+    errors: Error[];
 }
 
 declare global {
@@ -24,5 +26,6 @@ declare global {
 export default window.state = shallowReactive<Transient>({
     lastTenTicks: [],
     hasNaN: false,
-    NaNPath: []
+    NaNPath: [],
+    errors: reactive([])
 });

--- a/src/util/proxies.ts
+++ b/src/util/proxies.ts
@@ -40,7 +40,7 @@ export function createLazyProxy<T extends object, S extends T>(
     function calculateObj(): T {
         if (!calculated) {
             if (calculating) {
-                throw new Error("Cyclical dependency detected. Cannot evaluate lazy proxy.");
+                console.error("Cyclical dependency detected. Cannot evaluate lazy proxy.");
             }
             calculating = true;
             Object.assign(obj, objectFunc.call(obj, obj));

--- a/tests/game/formulas.test.ts
+++ b/tests/game/formulas.test.ts
@@ -227,14 +227,15 @@ describe("Creating Formulas", () => {
                     expect(formula.evaluate()).compare_tolerance(expectedValue));
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 /* @ts-ignore */
-                test("Invert throws", () => expect(() => formula.invert(25)).toThrow());
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                /* @ts-ignore */
-                test("Integrate throws", () => expect(() => formula.evaluateIntegral()).toThrow());
-                test("Invert integral throws", () =>
+                test("Invert errors", () => expect(() => formula.invert(25)).toLogError());
+                test("Integrate errors", () =>
                     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                     /* @ts-ignore */
-                    expect(() => formula.invertIntegral(25)).toThrow());
+                    expect(() => formula.evaluateIntegral()).toLogError());
+                test("Invert integral errors", () =>
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    /* @ts-ignore */
+                    expect(() => formula.invertIntegral(25)).toLogError());
             });
         }
         testConstant("number", () => Formula.constant(10));
@@ -256,10 +257,10 @@ describe("Creating Formulas", () => {
         // None of these formulas have variables, so they should all behave the same
         test("Is not marked as having a variable", () => expect(formula.hasVariable()).toBe(false));
         test("Is not invertible", () => expect(formula.isInvertible()).toBe(false));
-        test(`Formula throws if trying to invert`, () =>
+        test(`Formula errors if trying to invert`, () =>
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             /* @ts-ignore */
-            expect(() => formula.invert(10)).toThrow());
+            expect(() => formula.invert(10)).toLogError());
         test("Is not integrable", () => expect(formula.isIntegrable()).toBe(false));
         test("Has a non-invertible integral", () =>
             expect(formula.isIntegralInvertible()).toBe(false));
@@ -495,12 +496,12 @@ describe("Inverting", () => {
         test("Non-invertible constant", () => {
             const formula = Formula.add(variable, constant.ceil());
             expect(formula.isInvertible()).toBe(true);
-            expect(() => formula.invert(10)).not.toThrow();
+            expect(() => formula.invert(10)).not.toLogError();
         });
         test("Non-invertible variable", () => {
             const formula = Formula.add(variable.ceil(), constant);
             expect(formula.isInvertible()).toBe(false);
-            expect(() => formula.invert(10)).toThrow();
+            expect(() => formula.invert(10)).toLogError();
         });
     });
 });
@@ -624,19 +625,19 @@ describe("Integrating", () => {
 
     test("Integrating nested complex formulas", () => {
         const formula = Formula.pow(1.05, variable).times(100).pow(0.5);
-        expect(() => formula.evaluateIntegral()).toThrow();
+        expect(() => formula.evaluateIntegral()).toLogError();
     });
 
     describe("Integrating with non-integrable sections", () => {
         test("Non-integrable constant", () => {
             const formula = Formula.add(variable, constant.ceil());
             expect(formula.isIntegrable()).toBe(true);
-            expect(() => formula.evaluateIntegral()).not.toThrow();
+            expect(() => formula.evaluateIntegral()).not.toLogError();
         });
         test("Non-integrable variable", () => {
             const formula = Formula.add(variable.ceil(), constant);
             expect(formula.isIntegrable()).toBe(false);
-            expect(() => formula.evaluateIntegral()).toThrow();
+            expect(() => formula.evaluateIntegral()).toLogError();
         });
     });
 });
@@ -657,7 +658,7 @@ describe("Inverting integrals", () => {
     describe("Invertible Integral functions marked as such", () => {
         function checkFormula(formula: InvertibleIntegralFormula) {
             expect(formula.isIntegralInvertible()).toBe(true);
-            expect(() => formula.invertIntegral(10)).to.not.throw();
+            expect(() => formula.invertIntegral(10)).not.toLogError();
         }
         invertibleIntegralZeroPramFunctionNames.forEach(name => {
             describe(name, () => {
@@ -676,7 +677,7 @@ describe("Inverting integrals", () => {
                 test(`${name}(var, var) is marked as not having an invertible integral`, () => {
                     const formula = Formula[name](variable, variable);
                     expect(formula.isIntegralInvertible()).toBe(false);
-                    expect(() => formula.invertIntegral(10)).to.throw();
+                    expect(() => formula.invertIntegral(10)).toLogError();
                 });
             });
         });
@@ -732,7 +733,7 @@ describe("Inverting integrals", () => {
 
     test("Inverting integral of nested complex formulas", () => {
         const formula = Formula.pow(1.05, variable).times(100).pow(0.5);
-        expect(() => formula.invertIntegral(100)).toThrow();
+        expect(() => formula.invertIntegral(100)).toLogError();
     });
 });
 
@@ -765,7 +766,7 @@ describe("Step-wise", () => {
         );
         expect(() =>
             Formula.step(constant, 10, value => Formula.add(value, 10)).evaluateIntegral()
-        ).toThrow();
+        ).toLogError();
     });
 
     test("Formula never marked as having an invertible integral", () => {
@@ -774,7 +775,7 @@ describe("Step-wise", () => {
         ).toBe(false);
         expect(() =>
             Formula.step(constant, 10, value => Formula.add(value, 10)).invertIntegral(10)
-        ).toThrow();
+        ).toLogError();
     });
 
     test("Formula modifiers with variables mark formula as non-invertible", () => {
@@ -866,7 +867,7 @@ describe("Conditionals", () => {
         );
         expect(() =>
             Formula.if(constant, true, value => Formula.add(value, 10)).evaluateIntegral()
-        ).toThrow();
+        ).toLogError();
     });
 
     test("Formula never marked as having an invertible integral", () => {
@@ -875,7 +876,7 @@ describe("Conditionals", () => {
         ).toBe(false);
         expect(() =>
             Formula.if(constant, true, value => Formula.add(value, 10)).invertIntegral(10)
-        ).toThrow();
+        ).toLogError();
     });
 
     test("Formula modifiers with variables mark formula as non-invertible", () => {
@@ -976,7 +977,7 @@ describe("Custom Formulas", () => {
                     evaluate: () => 6,
                     invert: value => value
                 }).invert(10)
-            ).toThrow());
+            ).toLogError());
         test("One input inverts correctly", () =>
             expect(
                 new Formula({
@@ -1003,7 +1004,7 @@ describe("Custom Formulas", () => {
                     evaluate: () => 0,
                     integrate: stack => variable
                 }).evaluateIntegral()
-            ).toThrow());
+            ).toLogError());
         test("One input integrates correctly", () =>
             expect(
                 new Formula({
@@ -1030,7 +1031,7 @@ describe("Custom Formulas", () => {
                     evaluate: () => 0,
                     integrate: stack => variable
                 }).invertIntegral(20)
-            ).toThrow());
+            ).toLogError());
         test("One input inverts integral correctly", () =>
             expect(
                 new Formula({
@@ -1074,18 +1075,18 @@ describe("Buy Max", () => {
         resource = createResource(ref(100000));
     });
     describe("Without cumulative cost", () => {
-        test("Throws on calculating max affordable of non-invertible formula", () => {
+        test("Errors on calculating max affordable of non-invertible formula", () => {
             const purchases = ref(1);
             const variable = Formula.variable(purchases);
             const formula = Formula.abs(variable);
             const maxAffordable = calculateMaxAffordable(formula, resource, false);
-            expect(() => maxAffordable.value).toThrow();
+            expect(() => maxAffordable.value).toLogError();
         });
-        test("Throws on calculating cost of non-invertible formula", () => {
+        test("Errors on calculating cost of non-invertible formula", () => {
             const purchases = ref(1);
             const variable = Formula.variable(purchases);
             const formula = Formula.abs(variable);
-            expect(() => calculateCost(formula, 5, false, 0)).toThrow();
+            expect(() => calculateCost(formula, 5, false, 0)).toLogError();
         });
         test("Calculates max affordable and cost correctly", () => {
             const variable = Formula.variable(0);
@@ -1110,18 +1111,18 @@ describe("Buy Max", () => {
         });
     });
     describe("With cumulative cost", () => {
-        test("Throws on calculating max affordable of non-invertible formula", () => {
+        test("Errors on calculating max affordable of non-invertible formula", () => {
             const purchases = ref(1);
             const variable = Formula.variable(purchases);
             const formula = Formula.abs(variable);
             const maxAffordable = calculateMaxAffordable(formula, resource, true);
-            expect(() => maxAffordable.value).toThrow();
+            expect(() => maxAffordable.value).toLogError();
         });
-        test("Throws on calculating cost of non-invertible formula", () => {
+        test("Errors on calculating cost of non-invertible formula", () => {
             const purchases = ref(1);
             const variable = Formula.variable(purchases);
             const formula = Formula.abs(variable);
-            expect(() => calculateCost(formula, 5, true, 0)).toThrow();
+            expect(() => calculateCost(formula, 5, true, 0)).toLogError();
         });
         test("Estimates max affordable and cost correctly with 0 purchases", () => {
             const purchases = ref(0);
@@ -1266,7 +1267,7 @@ describe("Buy Max", () => {
         test("Handles direct sum of non-integrable formula", () => {
             const purchases = ref(0);
             const formula = Formula.variable(purchases).abs();
-            expect(() => calculateCost(formula, 10)).not.toThrow();
+            expect(() => calculateCost(formula, 10)).not.toLogError();
         });
     });
 });

--- a/tests/game/requirements.test.ts
+++ b/tests/game/requirements.test.ts
@@ -187,19 +187,9 @@ describe("Creating cost requirement", () => {
             unref(
                 createCostRequirement(() => ({
                     resource,
-                    cost: Formula.variable(resource).times(0),
-                    maxBulkAmount: 10
-                })).requirementMet
-            )
-        ).compare_tolerance(10));
-
-    test("Direct sum respected", () =>
-        expect(
-            unref(
-                createCostRequirement(() => ({
-                    resource,
-                    cost: Formula.variable(resource).times(0),
-                    maxBulkAmount: 10
+                    cost: Formula.variable(resource).times(0.0001),
+                    maxBulkAmount: 10,
+                    cumulativeCost: false
                 })).requirementMet
             )
         ).compare_tolerance(10));


### PR DESCRIPTION
This is a breaking change, and will require updating the docs.

- Removes challenge.maximize
- Removes repeatable.maximize
- Rename spendResources to cumulativeCost
- Rename summedPurchases to directSum
- calculateMaxAffordable now takes maxBulkAmount, and will support non-invertible formulas when maxBulkAmount < directSum
- Adds maxBulkAmount to cost requirements, defaulting to 1
- Adds directSum to cost requirements, which gets passed to calculateCost and calculateMaxAffordable
- Updates and adds tests for all these changes

So where previously you would set `maximize: true` on a repeatable or challenge, you'd now set `maxBulkAmount` on the cost requirement, such as `Decimal.dInf`.