### PR TITLE
Fix repeatables buying more than intended when `cumulativeCost` is `false`

### DIFF
--- a/src/game/formulas/formulas.ts
+++ b/src/game/formulas/formulas.ts
@@ -1453,7 +1453,9 @@ export function calculateMaxAffordable(
                     formula.invertIntegral(Decimal.add(resource.value, formula.evaluateIntegral()))
                 ).sub(unref(formula.innermostVariable) ?? 0);
             } else {
-                affordable = Decimal.floor(formula.invert(resource.value));
+                affordable = Decimal.floor(
+                    formula.invert(resource.value)
+                ).add(1).sub(unref(formula.innermostVariable) ?? 0);
             }
         }
         affordable = Decimal.clampMax(affordable, maxBulkAmount);


### PR DESCRIPTION
The logic for `calculateMaxAffordable` didn't account for how much of a repeatable you already bought so it ended up overshooting by a lot